### PR TITLE
(feature) puppet task for server cleanup wizard

### DIFF
--- a/tasks/cleanup.json
+++ b/tasks/cleanup.json
@@ -1,0 +1,32 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "description": "Perform a WSUS Server Cleanup.",
+  "input_method": "powershell",
+  "parameters": {
+    "cleanupobsoletecomputers": {
+      "description": "Deletes obsolete computers from the database.",
+      "type": "Boolean"
+    },
+    "cleanupobsoleteupdates": {
+      "description": "Deletes obsolete updates from the database.",
+      "type": "Boolean"
+    },
+    "cleanupunneededcontentfiles": {
+      "description": "Deletes unneeded update files.",
+      "type": "Boolean"
+    },
+    "compressupdates": {
+      "description": "Deletes obsolete revisions to updates from the database.",
+      "type": "Boolean"
+    },
+    "declineexpiredupdates": {
+      "description": "Declines expired updates.",
+      "type": "Boolean"
+    },
+    "declinesupersededupdates": {
+      "description": "Declines superseded updates..",
+      "type": "Boolean"
+    }
+  }
+}

--- a/tasks/cleanup.ps1
+++ b/tasks/cleanup.ps1
@@ -1,0 +1,33 @@
+[CmdletBinding()]
+Param(
+    [Boolean]
+    $CleanupObsoleteComputers,
+    [Boolean]
+    $CleanupObsoleteUpdates,
+    [Boolean]
+    $CleanupUnneededContentFiles,
+    [Boolean]
+    $CompressUpdates,
+    [Boolean]
+    $DeclineExpiredUpdates,
+    [Boolean]
+    $DeclineSupersededUpdates
+)
+$cleanup_report = Invoke-WsusServerCleanup @PSBoundParameters
+$_cleanup_report = @{}
+ForEach($operation_result in $cleanup_report)
+{
+    $parts = $operation_result.Split(':')
+    if ($_cleanup_report.ContainsKey($parts[0]))
+    {
+        $_cleanup_report[$parts[0]] += [int]$parts[1]
+    }
+    else
+    {
+        $_cleanup_report += @{
+            $parts[0] = [int]$parts[1]
+        }
+    }
+}
+
+ConvertTo-Json -InputObject $_cleanup_report -Compress


### PR DESCRIPTION
A puppet task that can be used to trigger a wsus server cleanup wizard run.  All applicable cleanup optionals are avaiable.

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the contributing section
    at https://github.com/tragiccode/tragiccode-wsusserver#contributing.

    Please prefix the PR title with the resource/class name,
    i.e. 'wsusserver_computer_target_group: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    i.e. 'BREAKING CHANGE: wsusserver_computer_target_group: My short description'.

    You may remove this and the other comments, but please keep the headers
    and the task list.
-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->

#### Task list
<!--
    To aid community reviewers in reviewing and merging your pull request (PR),
    please take the time to run through the below checklist.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [ ] Resource/Class documentation added/updated in README.md?
- [ ] Examples appropriately added/updated?
- [ ] Unit tests added/updated?
      See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible)?
      See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).