### PR TITLE
(bug) Uncomment WSUS initial synchronization exec

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ branches:
   - master
 
 install:
-  - set PATH=C:\Ruby22\bin;%PATH%
+  - set PATH=C:\Ruby24-x64\bin;%PATH%
   - bundle install --path .bundle
 
 build: off

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -334,30 +334,27 @@ class wsusserver::config(
       provider  => 'powershell',
     }
 
-    # Is this needed?
-    # Removing default products and classifications before initial sync
-
     # Get WSUS Subscription and perform initial synchronization to get:
     # 1. Types of updates availabile
     # 1. Products that are available
     # 1. Languages that are available
-    # exec { 'wsus-config-update-initial-synchronization':
-    #   command   => "\$ErrorActionPreference = \"Stop\"
-    #                 \$subscription = (Get-WsusServer).GetSubscription()
-    #                 \$subscription.StartSynchronizationForCategoryOnly()
-    #                 While (\$subscription.GetSynchronizationStatus() -ne 'NotProcessing') {
-    #                   Write-Output \".\" -NoNewline
-    #                   Start-Sleep -Seconds 5
-    #                 }",
-    #   unless    => "\$firstSyncResult = (Get-WsusServer).GetSubscription().GetSynchronizationHistory()[0]
-    #                 if (\$firstSyncResult.Result -eq 'Succeeded') {
-    #                   Exit 0
-    #                 }
-    #                 Exit 1",
-    #   logoutput => true,
-    #   timeout   => 3600,
-    #   provider  => 'powershell',
-    # }
+    exec { 'wsus-config-update-initial-synchronization':
+      command   => "\$ErrorActionPreference = \"Stop\"
+                    \$subscription = (Get-WsusServer).GetSubscription()
+                    \$subscription.StartSynchronizationForCategoryOnly()
+                    While (\$subscription.GetSynchronizationStatus() -ne 'NotProcessing') {
+                      Write-Output \".\" -NoNewline
+                      Start-Sleep -Seconds 5
+                    }",
+      unless    => "\$firstSyncResult = (Get-WsusServer).GetSubscription().GetSynchronizationHistory()[0]
+                    if (\$firstSyncResult.Result -eq 'Succeeded') {
+                      Exit 0
+                    }
+                    Exit 1",
+      logoutput => true,
+      timeout   => 3600,
+      provider  => 'powershell',
+    }
     # products we care about updates for ( office, sql server, windows server 2016, etc..)
         # TODO: 
     # 1.) handle * for all languages instead of having to explicitly list them out


### PR DESCRIPTION
During development i commented out wsus's initial synchronization task.  Unfortunately when users use this module this causes runs to say changes need to happen, attempt to be performed, but fail to truly happen but now blow up under the covers.  This causes the next run to do the same so puppet keeps attempting to converge the system until the initial sync is performed by the user.  This should resolve that issue.

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the contributing section
    at https://github.com/tragiccode/tragiccode-wsusserver#contributing.

    Please prefix the PR title with the resource/class name,
    i.e. 'wsusserver_computer_target_group: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    i.e. 'BREAKING CHANGE: wsusserver_computer_target_group: My short description'.

    You may remove this and the other comments, but please keep the headers
    and the task list.
-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->

#### Task list
<!--
    To aid community reviewers in reviewing and merging your pull request (PR),
    please take the time to run through the below checklist.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Resource/Class documentation added/updated in README.md?
- [x] Examples appropriately added/updated?
- [x] Unit tests added/updated?
- [x] Integration tests added/updated (where possible)?