### PR TITLE
wsusserver: fix comma separator in product or category name, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ class { 'wsusserver':
       'Windows Server 2016',
     ],
     update_classifications             => [
-        'Windows Server 2012',
-        'Windows Server 2016',
+        'Critical Updates',
+        'Security Updates',
+        'Updates',
     ],
 }
 ```
@@ -82,8 +83,9 @@ class { 'wsusserver':
       'Windows Server 2016',
     ],
     update_classifications             => [
-        'Windows Server 2012',
-        'Windows Server 2016',
+        'Critical Updates',
+        'Security Updates',
+        'Updates',
     ],
     targeting_mode                     => 'Client',
     host_binaries_on_microsoft_update  => false,
@@ -189,9 +191,10 @@ class { 'wsusserver':
       'Windows Server 2016',
     ],
     update_classifications             => [
-        'Windows Server 2012',
-        'Windows Server 2016',
-    ]
+        'Critical Updates',
+        'Security Updates',
+        'Updates',
+    ],
 }
 ```
 
@@ -210,7 +213,7 @@ class { 'wsusserver':
     #Status report email notification settings
     send_status_notification       => true,  
     status_notification_recipients => ['notifications@mydomain.com'],
-    notification_frequency         => 'Weekly',   # 'Weekly' or 'Daily' 
+    notification_frequency         => 'Weekly',   # 'Weekly' or 'Daily'
     notification_time_of_day       => '03:00:00', # 3AM ( UTC ) 24H Clock
 
     #SMTP Server Settings
@@ -218,7 +221,7 @@ class { 'wsusserver':
     smtp_sender_displayname        => 'WSUS Server Notifications',
     smtp_sender_emailaddress       => 'wsusserver@mydomain.com',
     ##Optional settings
-    smtp_port                      => 25,    
+    smtp_port                      => 25,
     ##Not yet implemented settings
     smtp_requires_authentication   => false,
     smtp_username                  => '',
@@ -370,7 +373,7 @@ The languages in which you want updates for.
 
 *Required.*
 
-The products in which you want updates for.
+The products (e.g. Windows Server 2008 R2), or product families (e.g. Windows) in which you want updates for. Product families contain one or many products, check the WSUS UI for clarification.
 
 **NOTE: This is required because this is specific to your organization's requirements.**
 
@@ -432,7 +435,7 @@ Default: false
 
 **NOTE: if set to `true` you must also specify sync_notification_recipient(s) and smtp server details**
 
-#### `sync_notification_recipients`   
+#### `sync_notification_recipients`
 
 Specifies the recipients of sync notification emails. Accepts an arrays of addresses, e.g. ['notifications@mydomain.com', 'another@mydomain.com']
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,17 @@ The languages in which you want updates for.
 
 *Required.*
 
-The products (e.g. Windows Server 2008 R2), or product families (e.g. Windows) in which you want updates for. Product families contain one or many products, check the WSUS UI for clarification.
+The specific products (e.g. Windows Server 2008 R2), or product families (e.g. Windows) in which you want updates for.
+
+Product families contain one or many products and are shown as groups in the product selection dialgue of the WSUS UI.
+
+Products are the individual products in these lists.
+
+One way to get a complete list is to run the following PowerShell command on a WSUS server:
+
+```powershell
+(Get-WsusServer).GetUpdateCategories() | sort title,type | ft title,type
+```
 
 **NOTE: This is required because this is specific to your organization's requirements.**
 

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ Products are the individual products in these lists.
 One way to get a complete list is to run the following PowerShell command on a WSUS server:
 
 ```powershell
-(Get-WsusServer).GetUpdateCategories() | sort title,type | ft title,type
+(Get-WsusServer).GetUpdateCategories() | Sort-Object -Property Title, Type | Format-Table -Property Title, Type
 ```
 
 **NOTE: This is required because this is specific to your organization's requirements.**

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -360,13 +360,13 @@ class wsusserver::config(
     # 1.) handle * for all languages instead of having to explicitly list them out
     # 2.) handle better idempotence just in case someone makes a change on the server in the ui? ( all products? )
     # 3.) Bomb out if the product specified by the user doesnt even exist in the possible list
-    $comma_seperated_products = join($products, ',')
+    $comma_seperated_products = join($products, ';')
     exec { 'wsus-config-update-products':
       command   => "\$ErrorActionPreference = \"Stop\"
                     \$wsusServerSubscription = (Get-WsusServer).GetSubscription()
                     \$allPossibleProducts = (Get-WsusServer).GetUpdateCategories()
                     \$coll = New-Object -TypeName Microsoft.UpdateServices.Administration.UpdateCategoryCollection
-                    \$allPossibleProducts | Where-Object { (\"${comma_seperated_products}\" -split \",\") -contains \$PSItem.Title  } | % { \$coll.Add(\$_) }        
+                    \$allPossibleProducts | Where-Object { (\"${comma_seperated_products}\" -split \";\") -contains \$PSItem.Title  } | ForEach-Object { \$coll.Add(\$_) }        
                     \$wsusServerSubscription.SetUpdateCategories(\$coll)
                     \$wsusServerSubscription.Save()",
       unless    => "\$wsusServerSubscription = (Get-WsusServer).GetSubscription()
@@ -391,13 +391,13 @@ class wsusserver::config(
     }
 
     # The update classifications we care about ( critical, security, defintion.. etc )
-    $comma_seperated_update_classifications = join($update_classifications, ',')
+    $comma_seperated_update_classifications = join($update_classifications, ';')
     exec { 'wsus-config-update-classifications':
       command   => "\$ErrorActionPreference = \"Stop\"
                     \$wsusServerSubscription = (Get-WsusServer).GetSubscription()            
                     \$allPossibleUpdateClassifications = (Get-WsusServer).GetUpdateClassifications()            
                     \$coll = New-Object -TypeName Microsoft.UpdateServices.Administration.UpdateClassificationCollection            
-                    \$allPossibleUpdateClassifications | Where-Object { (\"${comma_seperated_update_classifications}\" -split \",\") -contains \$PSItem.Title  } | % { \$coll.Add(\$_) }        
+                    \$allPossibleUpdateClassifications | Where-Object { (\"${comma_seperated_update_classifications}\" -split \";\") -contains \$PSItem.Title  } | ForEach-Object { \$coll.Add(\$_) }        
                     \$wsusServerSubscription.SetUpdateClassifications(\$coll)
                     \$wsusServerSubscription.Save()",
       unless    => "\$wsusServerSubscription = (Get-WsusServer).GetSubscription()         


### PR DESCRIPTION
#### Pull Request (PR) description
When adding a product family (e.g. a group of products - both are 'categories' in the wsus API), this module creates a comma separated list. unfortunately this breaks if the category has a comma in it, such as "Developer Tools, Runtimes, and Redistributables". I've changed both categories and classifications, but probably only category was necessary.

ReadMe also updated so that the examples are correct, there were product names (categories) in the example classification list. Some comments were added as to how to find the list of valid categories.

ran existing tests and all passed.

#### This Pull Request (PR) fixes the following issues
n/a

#### Task list
- [x] Resource/Class documentation added/updated in README.md?
- [ ] Examples appropriately added/updated?
- [x] Unit tests added/updated?
- [ ] Integration tests added/updated (where possible)?