### PR TITLE
replace dependency on dsc module

### DIFF
--- a/manifests/approvalrule.pp
+++ b/manifests/approvalrule.pp
@@ -37,13 +37,13 @@ define wsusserver::approvalrule (
             provider  => 'powershell',
         }
 
-        $comma_seperated_classifications = join($classifications, ',')
+        $semicolon_seperated_classifications = join($classifications, ';')
         exec { "update-wsus-approvalrule-classifications-${rule_name}":
             command   => "\$ErrorActionPreference = \"Stop\"
                           \$wsus = Get-WsusServer
                           \$approvalRule = \$wsus.GetInstallApprovalRules() | Where-Object { \$PSItem.Name -eq \"${rule_name}\" }
                           \$classificationCollection = New-Object -TypeName Microsoft.UpdateServices.Administration.UpdateClassificationCollection -ErrorAction Stop
-                          Get-WsusClassification | Select-Object -ExpandProperty Classification | Where-Object { (\"${comma_seperated_classifications}\" -split \",\") -contains \$PSItem.Title  } | % { \$classificationCollection.Add(\$_) }  
+                          Get-WsusClassification | Select-Object -ExpandProperty Classification | Where-Object { (\"${semicolon_seperated_classifications}\" -split \";\") -contains \$PSItem.Title  } | % { \$classificationCollection.Add(\$_) }  
                           \$approvalRule.SetUpdateClassifications(\$classificationCollection)
                           \$approvalRule.Save()",
             onlyif    => "\$ErrorActionPreference = \"Stop\"
@@ -54,7 +54,7 @@ define wsusserver::approvalrule (
                           {
                             \$currentApprovalClassifications = \"\"
                           }
-                          \$compareResult = Compare-Object -ReferenceObject \$currentApprovalClassifications -DifferenceObject (\"${comma_seperated_classifications}\").Split(\",\")
+                          \$compareResult = Compare-Object -ReferenceObject \$currentApprovalClassifications -DifferenceObject (\"${semicolon_seperated_classifications}\").Split(\";\")
                           if(\$compareResult -eq \$null)
                           {
                             # no differences
@@ -64,13 +64,13 @@ define wsusserver::approvalrule (
             provider  => 'powershell',
         }
 
-        $comma_seperated_products = join($products, ',')
+        $semicolon_seperated_products = join($products, ';')
         exec { "update-wsus-approvalrule-products-${rule_name}":
             command   => "\$ErrorActionPreference = \"Stop\"
                           \$wsus = Get-WsusServer
                           \$approvalRule = \$wsus.GetInstallApprovalRules() | Where-Object { \$PSItem.Name -eq \"${rule_name}\" }
                           \$productCollection = New-Object -TypeName Microsoft.UpdateServices.Administration.UpdateCategoryCollection
-                          Get-WsusProduct | Select-Object -ExpandProperty Product | Where-Object { (\"${comma_seperated_products}\" -split \",\") -contains \$PSItem.Title  } | % { \$productCollection.Add(\$_) }  
+                          Get-WsusProduct | Select-Object -ExpandProperty Product | Where-Object { (\"${semicolon_seperated_products}\" -split \";\") -contains \$PSItem.Title  } | % { \$productCollection.Add(\$_) }  
                           \$approvalRule.SetCategories(\$productCollection)
                           \$approvalRule.Save()",
             onlyif    => "\$ErrorActionPreference = \"Stop\"
@@ -81,7 +81,7 @@ define wsusserver::approvalrule (
                           {
                             \$currentApprovalCategories = \"\"
                           }
-                          \$compareResult = Compare-Object -ReferenceObject \$currentApprovalCategories -DifferenceObject (\"${comma_seperated_products}\").Split(\",\")
+                          \$compareResult = Compare-Object -ReferenceObject \$currentApprovalCategories -DifferenceObject (\"${semicolon_seperated_products}\").Split(\";\")
                           if(\$compareResult -eq \$null)
                           {
                             # no differences
@@ -91,13 +91,13 @@ define wsusserver::approvalrule (
             provider  => 'powershell',
         }
 
-        $comma_seperated_computer_groups = join($computer_groups, ',')
+        $semicolon_seperated_computer_groups = join($computer_groups, ';')
         exec { "update-wsus-approvalrule-computer-groups-${rule_name}":
             command   => "\$ErrorActionPreference = \"Stop\"
                           \$wsus = Get-WsusServer
                           \$approvalRule = \$wsus.GetInstallApprovalRules() | Where-Object { \$PSItem.Name -eq \"${rule_name}\" }
                           \$computerGroupCollection = New-Object -TypeName Microsoft.UpdateServices.Administration.ComputerTargetGroupCollection
-                          (Get-WsusServer).GetComputerTargetGroups() | Where-Object { (\"${comma_seperated_computer_groups}\" -split \",\") -contains \$PSItem.Name  } | % { \$computerGroupCollection.Add(\$_) }  
+                          (Get-WsusServer).GetComputerTargetGroups() | Where-Object { (\"${semicolon_seperated_computer_groups}\" -split \";\") -contains \$PSItem.Name  } | % { \$computerGroupCollection.Add(\$_) }  
                           \$approvalRule.SetComputerTargetGroups(\$computerGroupCollection)
                           \$approvalRule.Save()",
             onlyif    => "\$ErrorActionPreference = \"Stop\"
@@ -108,7 +108,7 @@ define wsusserver::approvalrule (
                           {
                             \$currentComputerTargetGroups = \"\"
                           }
-                          \$compareResult = Compare-Object -ReferenceObject \$currentComputerTargetGroups -DifferenceObject (\"${comma_seperated_computer_groups}\").Split(\",\")
+                          \$compareResult = Compare-Object -ReferenceObject \$currentComputerTargetGroups -DifferenceObject (\"${semicolon_seperated_computer_groups}\").Split(\";\")
                           if(\$compareResult -eq \$null)
                           {
                             # no differences

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,20 +8,18 @@ class wsusserver::install(
   Boolean $join_improvement_program                = $wsusserver::params::join_improvement_program,
 ) inherits wsusserver::params {
 
-  dsc_windowsfeature { 'UpdateServices':
-    dsc_ensure => $package_ensure,
-    dsc_name   => 'UpdateServices',
-    notify     => Exec["post install wsus content directory ${wsus_directory}"],
+  windowsfeature { 'UpdateServices':
+    ensure => $package_ensure,
+    notify => Exec["post install wsus content directory ${wsus_directory}"],
   }
 
   $_management_console_ensure = $include_management_console ? {
     true    => 'present',
     default => 'absent',
   }
-  dsc_windowsfeature { 'UpdateServices-UI':
-    dsc_ensure => $_management_console_ensure,
-    dsc_name   => 'UpdateServices-UI',
-    require    => Dsc_windowsfeature['UpdateServices'],
+  windowsfeature { 'UpdateServices-UI':
+    ensure  => $_management_console_ensure,
+    require => Windowsfeature['UpdateServices'],
   }
 
   $join_improvement_program_flag = bool2num($join_improvement_program)
@@ -40,6 +38,6 @@ class wsusserver::install(
     refreshonly => true,
     timeout     => 1200,
     provider    => 'powershell',
-    require     => [Dsc_windowsfeature['UpdateServices'], Dsc_windowsfeature['UpdateServices-UI']]
+    require     => [Windowsfeature['UpdateServices'], Windowsfeature['UpdateServices-UI']]
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -17,8 +17,8 @@
       "version_requirement": "2.x"
     },
     {
-      "name": "puppetlabs-dsc",
-      "version_requirement": "1.x"
+      "name": "puppet-windowsfeature",
+      "version_requirement": "3.x"
     }
   ],
   "operatingsystem_support": [
@@ -32,7 +32,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.1 < 6.0.0"
+      "version_requirement": ">= 4.7.1 < 7.0.0"
     }
   ]
 }


### PR DESCRIPTION
The puppetlabs/dsc module is quite big (thousands of files) to be dependent on, especially if all you need is to install a windows feature. Updated the code to use the puppet/windowsfeature module instead.