### PR TITLE
(GH-47) wsus-config-update-products: Fixes Duplicate Product Name Selection

### DIFF
--- a/manifests/approvalrule.pp
+++ b/manifests/approvalrule.pp
@@ -76,7 +76,7 @@ define wsusserver::approvalrule (
             onlyif    => "\$ErrorActionPreference = \"Stop\"
                           \$wsus = Get-WsusServer
                           \$approvalRule = \$wsus.GetInstallApprovalRules() | Where-Object { \$PSItem.Name -eq \"${rule_name}\" }
-                          \$currentApprovalCategories = \$approvalRule.GetCategories() | Select-Object -ExpandProperty Title
+                          \$currentApprovalCategories = \$approvalRule.GetCategories() | Select-Object -ExpandProperty Title -Unique
                           if(\$currentApprovalCategories -eq \$null)
                           {
                             \$currentApprovalCategories = \"\"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -386,11 +386,8 @@ class wsusserver::config(
                             Exit 3
                           }
                           else {
-                            \$matchingproduct = \$allPossibleProducts | Where-Object {\$_.Title -eq \$product -and \$_.type -eq \$Type}
-                            ForEach (\$product in \$matchingproduct) {
-                                # product title is valid. add it to the new collection
-                                [void]\$NewProducts.add( \$product )
-                            }
+                            # product title is valid. add it to the new collection
+                            [void]\$NewProducts.addRange( (\$allPossibleProducts | Where-Object {\$_.Title -eq \$product -and \$_.type -eq \$Type}) )
                           }
                         }
                       }
@@ -406,7 +403,7 @@ class wsusserver::config(
                       \$wsusServerSubscription.GetUpdateCategories() | ForEach-Object {[void]\$currentProducts.add(\$_)}
 
                       # get products configured that match the supplied type
-                      \$referenceObject = \$currentProducts | where-object {\$_.type -eq \$Type} | Select-Object -ExpandProperty Title
+                      \$referenceObject = \$currentProducts | where-object {\$_.type -eq \$Type} | Select-Object -ExpandProperty Title -Unique 
 
                       # if none, blank array for object compare
                       if (\$null -eq \$referenceObject) { \$referenceObject = @('') }
@@ -511,17 +508,12 @@ class wsusserver::config(
                     else {
                       \$desired_products = \$commaSeparatedProducts.Split(\";\")
                       \$desired_productfamilies = \$commaSeparatedProductFamilies.Split(\";\")
-                      #Find all matching products name in the case of multiples
-                      \$desired_products = ((Get-WsusServer).GetUpdateCategories() | Where-Object {\$_.type -eq \"product\" -and \$desired_products -eq \$_.Title }).Title
-                      \$desired_productfamilies = ((Get-WsusServer).GetUpdateCategories() | Where-Object {\$_.type -eq \"productfamily\" -and \$desired_productfamilies -eq \$_.Title }).Title
                     }
-                    #Set desired_productfamilies to blank array if null
-                    if (\$null -eq \$desired_productfamilies) { \$desired_productfamilies = @('') }
                     # get current enabled product families, blank array if none
-                    \$currentEnabledProductFamilies = (\$wsusServerSubscription.GetUpdateCategories() | Where-Object {\$_.type -eq \"productfamily\"}).Title
+                    \$currentEnabledProductFamilies = (\$wsusServerSubscription.GetUpdateCategories() | Where-Object {\$_.type -eq \"productfamily\"}).Title | Select-Object -Unique
                     if (\$null -eq \$currentEnabledProductFamilies) { \$currentEnabledProductFamilies = @('') }
                     # get current enabled products, blank array if none
-                    \$currentEnabledProducts = (\$wsusServerSubscription.GetUpdateCategories() | Where-Object {\$_.type -eq \"product\"}).Title
+                    \$currentEnabledProducts = (\$wsusServerSubscription.GetUpdateCategories() | Where-Object {\$_.type -eq \"product\"}).Title | Select-Object -Unique
                     if (\$null -eq \$currentEnabledProducts) { \$currentEnabledProducts = @('') }
                     # compare product families
                     \$compareProductFamiliesResult = Compare-Object -ReferenceObject \$currentEnabledProductFamilies -DifferenceObject \$desired_productfamilies

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -389,7 +389,6 @@ class wsusserver::config(
                             \$matchingproduct = \$allPossibleProducts | Where-Object {\$_.Title -eq \$product -and \$_.type -eq \$Type}
                             ForEach (\$product in \$matchingproduct) {
                                 # product title is valid. add it to the new collection
-                                #[void]\$NewProducts.add( (\$allPossibleProducts | Where-Object {\$_.Title -eq \$product -and \$_.type -eq \$Type} | Select-Object -Index 0) )
                                 [void]\$NewProducts.add( \$product )
                             }
                           }
@@ -402,12 +401,12 @@ class wsusserver::config(
 
                       # get all current synced products
                       \$currentProducts = New-Object -TypeName Microsoft.UpdateServices.Administration.UpdateCategoryCollection
-                     
+
                       # add currently enabled products and product families to the collection object
                       \$wsusServerSubscription.GetUpdateCategories() | ForEach-Object {[void]\$currentProducts.add(\$_)}
 
                       # get products configured that match the supplied type
-                      \$referenceObject = \$currentProducts | where-object {\$_.type -eq \$Type} | Select-Object -ExpandProperty Title #-Unique 
+                      \$referenceObject = \$currentProducts | where-object {\$_.type -eq \$Type} | Select-Object -ExpandProperty Title
 
                       # if none, blank array for object compare
                       if (\$null -eq \$referenceObject) { \$referenceObject = @('') }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -386,8 +386,12 @@ class wsusserver::config(
                             Exit 3
                           }
                           else {
-                            # product title is valid. add it to the new collection
-                            [void]\$NewProducts.add( (\$allPossibleProducts | Where-Object {\$_.Title -eq \$product -and \$_.type -eq \$Type} | Select-Object -First 1) )
+                            \$matchingproduct = \$allPossibleProducts | Where-Object {\$_.Title -eq \$product -and \$_.type -eq \$Type}
+                            ForEach (\$product in \$matchingproduct) {
+                                # product title is valid. add it to the new collection
+                                #[void]\$NewProducts.add( (\$allPossibleProducts | Where-Object {\$_.Title -eq \$product -and \$_.type -eq \$Type} | Select-Object -Index 0) )
+                                [void]\$NewProducts.add( \$product )
+                            }
                           }
                         }
                       }
@@ -398,12 +402,12 @@ class wsusserver::config(
 
                       # get all current synced products
                       \$currentProducts = New-Object -TypeName Microsoft.UpdateServices.Administration.UpdateCategoryCollection
-
+                     
                       # add currently enabled products and product families to the collection object
                       \$wsusServerSubscription.GetUpdateCategories() | ForEach-Object {[void]\$currentProducts.add(\$_)}
 
                       # get products configured that match the supplied type
-                      \$referenceObject = \$currentProducts | where-object {\$_.type -eq \$Type} | Select-Object -ExpandProperty Title -Unique 
+                      \$referenceObject = \$currentProducts | where-object {\$_.type -eq \$Type} | Select-Object -ExpandProperty Title #-Unique 
 
                       # if none, blank array for object compare
                       if (\$null -eq \$referenceObject) { \$referenceObject = @('') }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -512,7 +512,12 @@ class wsusserver::config(
                     else {
                       \$desired_products = \$commaSeparatedProducts.Split(\";\")
                       \$desired_productfamilies = \$commaSeparatedProductFamilies.Split(\";\")
+                      #Find all matching products name in the case of multiples
+                      \$desired_products = ((Get-WsusServer).GetUpdateCategories() | Where-Object {\$_.type -eq \"product\" -and \$desired_products -eq \$_.Title }).Title
+                      \$desired_productfamilies = ((Get-WsusServer).GetUpdateCategories() | Where-Object {\$_.type -eq \"productfamily\" -and \$desired_productfamilies -eq \$_.Title }).Title
                     }
+                    #Set desired_productfamilies to blank array if null
+                    if (\$null -eq \$desired_productfamilies) { \$desired_productfamilies = @('') }
                     # get current enabled product families, blank array if none
                     \$currentEnabledProductFamilies = (\$wsusServerSubscription.GetUpdateCategories() | Where-Object {\$_.type -eq \"productfamily\"}).Title
                     if (\$null -eq \$currentEnabledProductFamilies) { \$currentEnabledProductFamilies = @('') }


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the contributing section
    at https://github.com/tragiccode/tragiccode-wsusserver#contributing.

    Please prefix the PR title with the resource/class name,
    i.e. 'wsusserver_computer_target_group: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    i.e. 'BREAKING CHANGE: wsusserver_computer_target_group: My short description'.

    You may remove this and the other comments, but please keep the headers
    and the task list.
-->
#### Pull Request (PR) description
<!--
    PowerShell code changes to resolve Issue #46 which is causing products not to be selected when they have the exact same name.
-->

#### This Pull Request (PR) fixes the following issues
 Fixes #46 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your pull request (PR),
    please take the time to run through the below checklist.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [ ] Resource/Class documentation added/updated in README.md?
- [ ] Examples appropriately added/updated?
- [ ] Unit tests added/updated?
- [ ] Integration tests added/updated (where possible)?