### PR TITLE
Tests pass with newer versions of Puppet and the dependencies.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,16 +9,16 @@
   "issues_url": "https://github.com/TraGicCode/tragiccode-wsusserver/issues",
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
-      "version_requirement": "4.x"
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.0.0 < 7.0.0"
     },
     {
-      "name": "puppetlabs-powershell",
-      "version_requirement": "2.x"
+      "name": "puppetlabs/powershell",
+      "version_requirement": ">= 2.0.0 < 5.0.0"
     },
     {
-      "name": "puppetlabs-dsc",
-      "version_requirement": "1.x"
+      "name": "puppetlabs/dsc",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -33,7 +33,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.1 < 6.0.0"
+      "version_requirement": ">= 4.7.1 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
#### Pull Request (PR) description
There was a request to have this work with a newer version of puppetlabs/stdlib:

https://github.com/TraGicCode/tragiccode-wsusserver/issues/45

I updated all the dependencies in the metadata.json file and the tests still pass. I've also changed them to use the format Puppet uses in their own modules.

#### This Pull Request (PR) fixes the following issues
Fixed #45

#### Task list
- [ ] Resource/Class documentation added/updated in README.md?
- [ ] Examples appropriately added/updated?
- [ ] Unit tests added/updated?
- [ ] Integration tests added/updated (where possible)?