### PR TITLE
wsusserver_install: Remove DSC dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
     repositories:
       stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
       powershell: 'https://github.com/puppetlabs/puppetlabs-powershell.git'
-      dsc: 'https://github.com/puppetlabs/puppetlabs-dsc.git'
+      windowsfeature: 'https://github.com/voxpupuli/puppet-windowsfeature.git'
     symlinks:
       wsusserver: "#{source_dir}"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,20 +8,18 @@ class wsusserver::install(
   Boolean $join_improvement_program                = $wsusserver::params::join_improvement_program,
 ) inherits wsusserver::params {
 
-  dsc_windowsfeature { 'UpdateServices':
-    dsc_ensure => $package_ensure,
-    dsc_name   => 'UpdateServices',
-    notify     => Exec["post install wsus content directory ${wsus_directory}"],
+  windowsfeature { 'UpdateServices':
+    ensure => $package_ensure,
+    notify => Exec["post install wsus content directory ${wsus_directory}"],
   }
 
   $_management_console_ensure = $include_management_console ? {
     true    => 'present',
     default => 'absent',
   }
-  dsc_windowsfeature { 'UpdateServices-UI':
-    dsc_ensure => $_management_console_ensure,
-    dsc_name   => 'UpdateServices-UI',
-    require    => Dsc_windowsfeature['UpdateServices'],
+  windowsfeature { 'UpdateServices-UI':
+    ensure  => $_management_console_ensure,
+    require => Windowsfeature['UpdateServices'],
   }
 
   $join_improvement_program_flag = bool2num($join_improvement_program)
@@ -40,6 +38,6 @@ class wsusserver::install(
     refreshonly => true,
     timeout     => 1200,
     provider    => 'powershell',
-    require     => [Dsc_windowsfeature['UpdateServices'], Dsc_windowsfeature['UpdateServices-UI']]
+    require     => [Windowsfeature['UpdateServices'], Windowsfeature['UpdateServices-UI']]
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -17,8 +17,8 @@
       "version_requirement": ">= 2.0.0 < 5.0.0"
     },
     {
-      "name": "puppetlabs/dsc",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "name": "puppet/windowsfeature",
+      "version_requirement": "3.x"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -6,15 +6,13 @@ describe 'wsusserver::install' do
     it { is_expected.to contain_class('wsusserver::params') }
 
     it {
-      is_expected.to contain_dsc_windowsfeature('UpdateServices')
-        .with(dsc_ensure: 'present',
-              dsc_name: 'UpdateServices')
+      is_expected.to contain_windowsfeature('UpdateServices')
+        .with(ensure: 'present',)
     }
 
     it {
-      is_expected.to contain_dsc_windowsfeature('UpdateServices-UI')
-        .with(dsc_ensure: 'present',
-              dsc_name: 'UpdateServices-UI')
+      is_expected.to contain_windowsfeature('UpdateServices-UI')
+        .with(ensure: 'present',)
     }
 
     it {
@@ -35,9 +33,8 @@ describe 'wsusserver::install' do
     end
 
     it {
-      is_expected.to contain_dsc_windowsfeature('UpdateServices')
-        .with(dsc_ensure: 'absent',
-              dsc_name: 'UpdateServices')
+      is_expected.to contain_windowsfeature('UpdateServices')
+        .with(ensure: 'absent',)
     }
     # TODO: I should uninstall this feature if the whole thing is getting uninstalled
     # it { should contain_dsc_windowsfeature('UpdateServices-UI').with({
@@ -54,9 +51,8 @@ describe 'wsusserver::install' do
     end
 
     it {
-      is_expected.to contain_dsc_windowsfeature('UpdateServices-UI')
-        .with(dsc_ensure: 'absent',
-              dsc_name: 'UpdateServices-UI')
+      is_expected.to contain_windowsfeature('UpdateServices-UI')
+        .with(ensure: 'absent',)
     }
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
<!--
The DSC module is no longer recommended by Puppet. It requires syncing thousands of files to every computer that checks into a given Puppet environment. Thankfully its use was rather trivial here and can easily be replaced by the dedicated windowsfeature module. Thanks to Kevin Reeuwijk for initially raising this issue and putting in a PR.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    n/a
-->

#### Task list
<!--
    To aid community reviewers in reviewing and merging your pull request (PR),
    please take the time to run through the below checklist.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [ ] Resource/Class documentation added/updated in README.md?
- [ ] Examples appropriately added/updated?
- [ ] Unit tests added/updated?
- [ ] Integration tests added/updated (where possible)?