### PR TITLE
wsus-config-update-initial-synchronization: Get initial sync result in stead of most recent sync result.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -347,8 +347,8 @@ class wsusserver::config(
                       Write-Output \".\" -NoNewline
                       Start-Sleep -Seconds 5
                     }",
-      unless    => "\$firstSyncResult = (Get-WsusServer).GetSubscription().GetSynchronizationHistory()[-1]
-                    if (\$firstSyncResult.Result -eq 'Succeeded') {
+      unless    => "\$SyncResults = (Get-WsusServer).GetSubscription().GetSynchronizationHistory()
+                    if ((\$SyncResults[-1].Result -eq 'Succeeded') -or (\$SyncResults.Count -ge 5)) {
                       Exit 0
                     }
                     Exit 1",

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -347,7 +347,7 @@ class wsusserver::config(
                       Write-Output \".\" -NoNewline
                       Start-Sleep -Seconds 5
                     }",
-      unless    => "\$firstSyncResult = (Get-WsusServer).GetSubscription().GetSynchronizationHistory()[0]
+      unless    => "\$firstSyncResult = (Get-WsusServer).GetSubscription().GetSynchronizationHistory()[-1]
                     if (\$firstSyncResult.Result -eq 'Succeeded') {
                       Exit 0
                     }


### PR DESCRIPTION
#### Pull Request (PR) description
Retrieve the initial sync result instead of the most recent sync result to prevent recurring initial syncs.

#### This Pull Request (PR) fixes the following issues
Fixes #66

#### Task list
- [ ] Resource/Class documentation added/updated in README.md?
- [ ] Examples appropriately added/updated?
- [ ] Unit tests added/updated?
- [ ] Integration tests added/updated (where possible)?